### PR TITLE
Ensure signed in fix

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -52,7 +52,7 @@ AccountsTemplates.setPrevPath = function(newPath) {
 AccountsTemplates.ensureSignedIn = function(context, redirect) {
   if (!Meteor.userId()) {
     // if we're not already on an AT route
-    if (!_.contains(AccountsTemplates.knownRoutes, context.path)) {
+    if (!_.contains(AccountsTemplates.knownRoutes, context.route.name)) {
 
       AccountsTemplates.setState(AccountsTemplates.options.defaultState, function() {
         var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
@@ -73,11 +73,11 @@ AccountsTemplates.ensureSignedIn = function(context, redirect) {
 // Stores previous path on path change...
 FlowRouter.triggers.enter([
   function(context) {
-    var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(path) {
-      if (!path) {
+    var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(route) {
+      if (!route) {
         return false;
       }
-      var known = RegExp(path).test(context.path);
+      var known = RegExp(route).test(context.route.name);
       return known;
     });
     if (!_.some(isKnownRoute)) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -96,7 +96,7 @@ AccountsTemplates.configureRoute = function(route, options) {
   this.routes[route] = options;
 
   // Known routes are used to filter out previous path for redirects...
-  AccountsTemplates.knownRoutes.push(options.path);
+  AccountsTemplates.knownRoutes.push(options.name);
 
   if (Meteor.isServer) {
     // Configures "reset password" email link


### PR DESCRIPTION
Because the new ensureSignedIn is checking paths, the routes that have tokens aren't properly matching  and are thus all routing to the signin page.  This patch switches the check to be based on route name rather than path.