### PR TITLE
EnsureSignedIn fix

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -52,7 +52,7 @@ AccountsTemplates.setPrevPath = function(newPath) {
 AccountsTemplates.ensureSignedIn = function(context, redirect) {
   if (!Meteor.userId()) {
     // if we're not already on an AT route
-    if (!_.contains(AccountsTemplates.knownRoutes, context.path)) {
+    if (!_.contains(AccountsTemplates.knownRoutes, context.route.name)) {
 
       AccountsTemplates.setState(AccountsTemplates.options.defaultState, function() {
         var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
@@ -73,11 +73,11 @@ AccountsTemplates.ensureSignedIn = function(context, redirect) {
 // Stores previous path on path change...
 FlowRouter.triggers.enter([
   function(context) {
-    var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(path) {
-      if (!path) {
+    var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(route) {
+      if (!route) {
         return false;
       }
-      var known = RegExp(path).test(context.path);
+      var known = RegExp(route).test(context.route.name);
       return known;
     });
     if (!_.some(isKnownRoute)) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -96,7 +96,11 @@ AccountsTemplates.configureRoute = function(route, options) {
   this.routes[route] = options;
 
   // Known routes are used to filter out previous path for redirects...
-  AccountsTemplates.knownRoutes.push(options.name);
+  if (route==="verifyEmail") {  // this route has a different naming convention on line 160 below... is that intentional?
+    AccountsTemplates.knownRoutes.push(options.name);
+  } else {
+    AccountsTemplates.knownRoutes.push(route);
+  }
 
   if (Meteor.isServer) {
     // Configures "reset password" email link

--- a/lib/core.js
+++ b/lib/core.js
@@ -96,7 +96,7 @@ AccountsTemplates.configureRoute = function(route, options) {
   this.routes[route] = options;
 
   // Known routes are used to filter out previous path for redirects...
-  AccountsTemplates.knownRoutes.push(options.path);
+  AccountsTemplates.knownRoutes.push(options.name);
 
   if (Meteor.isServer) {
     // Configures "reset password" email link


### PR DESCRIPTION
The new ensureSignedIn uses paths to check for routes that should be allowed without signin.  But for routes with tokens (ex. verifyEmail), the compare wasn't working.  This instead switches to comparing on route names rather than paths.