### PR TITLE
Fix route name. Should not be the route code.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -175,7 +175,7 @@ AccountsTemplates.configureRoute = function(route, options) {
       });
     } else {
       FlowRouter.route(path, {
-        name: route,
+        name: name,
         triggersEnter: [
           function() {
             AccountsTemplates.setState(route);
@@ -189,7 +189,7 @@ AccountsTemplates.configureRoute = function(route, options) {
     }
   } else {
     FlowRouter.route(path, {
-      name: route,
+      name: name,
       triggersEnter: [
         function() {
           var redirect = false;


### PR DESCRIPTION
The names have the 'at' prefixes, presumably to prevent name clashes with  routes created by the app or other packages. You use the correct name on line 156, so these other 2 lines should probably be the same.