### PR TITLE
Special case for validation-error

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -160,10 +160,19 @@ AccountsTemplates.submitCallback = function(error, state, onSuccess) {
 
   if (error) {
     if (_.isObject(error.details)) {
-      // If error.details is an object, we may try to set fields errors from it
-      _.each(error.details, function(error, fieldId) {
-        AccountsTemplates.getField(fieldId).setError(error);
-      });
+      if (error.error === 'validation-error') {
+        // This error is a ValidationError from the mdg:validation-error package.
+        // It has a well-defined error format
+        _.each(error.details, function(fieldError) {
+          // XXX in the future, this should have a way to do i18n
+          AccountsTemplates.getField(fieldError.name).setError(fieldError.type);
+        });
+      } else {
+        // If error.details is an object, we may try to set fields errors from it
+        _.each(error.details, function(error, fieldId) {
+          AccountsTemplates.getField(fieldId).setError(error);
+        });
+      }
     } else {
       var err = 'error.accounts.Unknown error';
       if (error.reason) {

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -163,10 +163,24 @@ AccountsTemplates.submitCallback = function(error, state, onSuccess) {
       if (error.error === 'validation-error') {
         // This error is a ValidationError from the mdg:validation-error package.
         // It has a well-defined error format
+
+        // Record errors that don't correspond to fields in the form
+        var errorsWithoutField = [];
+
         _.each(error.details, function(fieldError) {
-          // XXX in the future, this should have a way to do i18n
-          AccountsTemplates.getField(fieldError.name).setError(fieldError.type);
+          var field = AccountsTemplates.getField(fieldError.name);
+
+          if (field) {
+            // XXX in the future, this should have a way to do i18n
+            field.setError(fieldError.type);
+          } else {
+            errorsWithoutField(fieldError.type);
+          }
         });
+
+        if (errorsWithoutField) {
+          AccountsTemplates.state.form.set('error', errorsWithoutField);
+        }
       } else {
         // If error.details is an object, we may try to set fields errors from it
         _.each(error.details, function(error, fieldId) {

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -174,7 +174,7 @@ AccountsTemplates.submitCallback = function(error, state, onSuccess) {
             // XXX in the future, this should have a way to do i18n
             field.setError(fieldError.type);
           } else {
-            errorsWithoutField(fieldError.type);
+            errorsWithoutField.push(fieldError.type);
           }
         });
 


### PR DESCRIPTION
In the upcoming Meteor Guide, we're working to have a standardized format for validation errors, which contain information about the type of error and the relevant field. This PR will allow me to use code like the below to validate new users:

```js
// Ensuring every user has an email address, should be in server-side code
Accounts.validateNewUser((user) => {
  new SimpleSchema({
    _id: { type: String },
    emails: { type: Array },
    'emails.$': { type: Object },
    'emails.$.address': { type: String },
    'emails.$.verified': { type: Boolean },
    createdAt: { type: Date },
    services: { type: Object, blackbox: true }
  }).validate(user);

  // Return true to allow user creation to proceed
  return true;
});
```