### PR TITLE
VerifyEmail should not be called on the client.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -194,7 +194,6 @@ AccountsTemplates.configureRoute = function(route, options) {
     }
 
     layoutRegions[contentRegion] = React.createElement(BlazeToReact, { blazeTemplate: template });
-
   }
 
   function doLayout() {
@@ -226,12 +225,14 @@ AccountsTemplates.configureRoute = function(route, options) {
           doLayout();
 
           var token = params.paramToken;
-          Accounts.verifyEmail(token, function(error) {
-            AccountsTemplates.setDisabled(false);
-            AccountsTemplates.submitCallback(error, route, function() {
-              AccountsTemplates.state.form.set("result", AccountsTemplates.texts.info.emailVerified);
-            });
-          });
+          if (Meteor.isClient) {
+             Accounts.verifyEmail(token, function(error) {
+               AccountsTemplates.setDisabled(false);
+               AccountsTemplates.submitCallback(error, route, function() {
+                 AccountsTemplates.state.form.set("result", AccountsTemplates.texts.info.emailVerified);
+               });
+             });
+          }
         }
       });
     } else {


### PR DESCRIPTION
When using FlowRouter 3 with SSR support the routes are also executed on the server, however `Accounts.verifyEmail()` (which is executed when visiting the `atVerifyEmail` route) is only available on the client and caused a server error. This PR fixes that.

