### PR TITLE
Use react-mounter on Meteor 1.3+

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -175,13 +175,17 @@ AccountsTemplates.configureRoute = function(route, options) {
     //
     // For now we need to render the main template using BlazeToReact
 
-    if (Package['react-runtime']) {
+    if (require) {
+      var React = require('react');
+    } else if (Package['react-runtime']) {
       var React = Package['react-runtime'].React;
     } else {
       throw new Error("layoutTemplate is a React element but React runtime package is not found");
     }
 
-    if (Package['kadira:react-layout']) {
+    if (require) {
+      var ReactLayout = {render: require('react-mounter').mount};
+    } else if (Package['kadira:react-layout']) {
       var ReactLayout = Package['kadira:react-layout'].ReactLayout;
     } else {
       throw new Error("useraccounts:flow-routing requires that your project includes kadira:react-layout package.");

--- a/package.js
+++ b/package.js
@@ -29,9 +29,7 @@ Package.onUse(function(api) {
   ], ['client', 'server']);
 
   api.use([
-     'react@0.14.1_1',
      'kadira:blaze-layout@2.3.0',
-     'kadira:react-layout@1.5.2',
      'gwendall:blaze-to-react@0.1.2'
   ], ['client', 'server'], { weak: true });
 


### PR DESCRIPTION
If 'require' is available, use it to gather the dependencies
needed to mount the React component that wraps our templates,
namely 'react' and 'react-mounter'.

This dependencies are not required in 'package.js' because of
the warnings in Meteor Guide[1].

In addition, 'kadira:react-layout' and 'react' atmosphere packages
are removed to avoid conflicts with NPM packages when 'flow-routing'
is used in a Meteor 1.3+ application.

Unfortunately this means that applications written for prior versions
of Meteor should now explicitly include them.

[1] https://guide.meteor.com/writing-atmosphere-packages.html#peer-npm-dependencies