### PR TITLE
allow to pickup value from query string a assing to any form control

### DIFF
--- a/lib/client/templates_helpers/at_input.js
+++ b/lib/client/templates_helpers/at_input.js
@@ -9,6 +9,6 @@ AccountsTemplates.atInputRendered.push(function(){
   var queryKey = this.data.options && this.data.options.queryKey || fieldId;
   var inputQueryVal = FlowRouter.getQueryParam(queryKey);
   if (inputQueryVal) {
-    this.$("input#at-field-" + fieldId).val(inputQueryVal);
+    this.$("[name]#at-field-" + fieldId).val(inputQueryVal);
   }
 });


### PR DESCRIPTION
Before only input values can pickup values form query string

before: this.$("input#at-field-" + fieldId).val(inputQueryVal);
now: this.$("[name]#at-field-" + fieldId).val(inputQueryVal);